### PR TITLE
Modify import package and change error type

### DIFF
--- a/output.go
+++ b/output.go
@@ -22,7 +22,7 @@ package markdown
 import (
 	"fmt"
 	"log"
-	"math/rand"
+	"rand"
 	"strings"
 )
 

--- a/output.go
+++ b/output.go
@@ -24,12 +24,13 @@ import (
 	"log"
 	"rand"
 	"strings"
+	"os"
 )
 
 type Writer interface {
-	WriteString(string) (int, error)
-	WriteRune(int) (int, error)
-	WriteByte(byte) error
+	WriteString(string) (int, os.Error)
+	WriteRune(int) (int, os.Error)
+	WriteByte(byte) os.Error
 }
 
 type htmlOut struct {


### PR DESCRIPTION
Hi, knieriem.

I was working on my project using your markdown package. When the markdown package was being installed, it was failed. The math/rand package name has changed to rand and error type has changed to os.Error.

This is patch modified two changes into the latest go version.

Thanks,

Taehun Kim.
